### PR TITLE
Add ver tag documentation

### DIFF
--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -19,7 +19,15 @@ As a SciToken is a [JSON Web Token](https://jwt.io) at its base, we inherit a sp
 
 * *iss* (Issuer): The issuer of the SciTokens; this MUST be populated in a token chain.  It MUST contain a unique URL for the organization; this unique key will later be used for validation and bootstrapping trust roots.  This is used to identify the virtual organization (VO) that issues the token; it is expected that services maintain a map of issuer URLs to coarse-grained authorizations.
 
-* *aud* (Audience): A service the SciToken is authorized to access.  For example, if the VO has write access to several storage services, this claim may be utilized to limit a token to a single endpoint URI.  As in RFC7519, the `aud` claim is not necessarily a URI: for example, it might be the name of a target site.   The service may accept several different possible audiences; the service endpoint at `https://storage.example.com` may accept an audience of either `Site_Example` or `https://storage.example.com` but ought to reject an audience of `https://www.google.com`.  The `aud` claim is OPTIONAL in version 1.0, mandatory in 2.0.
+* *aud* (Audience): A service the SciToken is authorized to access.  For example, if the VO has write access to several storage services, this claim may be utilized to limit a token to a single endpoint URI.  As in RFC7519, the `aud` claim is not necessarily a URI: for example, it might be the name of a target site.   The service may accept several different possible audiences; the service endpoint at `https://storage.example.com` may accept an audience of either `Site_Example` or `https://storage.example.com` but ought to reject an audience of `https://www.google.com`.  Additionally, the `aud` can be a special value of `ANY`, where it would allow any audience to match.  The `aud` claim is OPTIONAL in version 1.0, mandatory in 2.0.
+
+  | Client      | Server      | Result  |
+  |-------------|-------------|---------|
+  | ANY         | ANY         | Success |
+  | ANY         | example.com | Success |
+  | example.com | ANY         | Fail    |
+  | example.com | example.com | Success |
+  | notwork.com | example.com | Fail    |
 
 * *jti* (JWT ID): The interpretation for `jti` is unchanged from the RFC. It is a unique identifier that protects against replay attacks, improves traceability of tokens through a distributed system, and enables revocation.  The `jti` claim is OPTIONAL.
 
@@ -148,11 +156,10 @@ To stageout to `/store/user/bbockelm`, a part of the CMS namespace at the CMS si
 {
    "scope": "write:/store/user/bbockelm",
    "iss":   "https://cms.cern/oauth",
-   "site":  "T2_US_Nebraska"
 }
 ```
 
-The implementation of `site` is purposely ambiguous; hence, the `aud` claim must be used to restrict a token to a specific endpoint:
+The `aud` claim must be used to restrict a token to a specific endpoint:
 
 ```
 {

--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -23,7 +23,7 @@ As a SciToken is a [JSON Web Token](https://jwt.io) at its base, we inherit a sp
 
 * *jti* (JWT ID): The interpretation for `jti` is unchanged from the RFC. It is a unique identifier that protects against replay attacks, improves traceability of tokens through a distributed system, and enables revocation.  The `jti` claim is OPTIONAL.
 
-* *ver* (Version): The version of the token.  `ver` is used to version the claim formats and attribute names.  The format of the `ver` claim is: `<profile>:<version>`.  The `ver` claim is optional.  If absent, the default is `scitoken:1.0`
+* *ver* (Version): The version of the token.  `ver` is used to version the claim formats and attribute names.  The format of the `ver` claim is: `<profile>:<version>`.  The `ver` claim is optional in SciTokens 1.0 but mandatory in all other versions; if absent, clients MUST process the token as belonging to the SciTokens 1.0 profile
 
 SciToken Claim Semantics
 ------------------------

--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -23,11 +23,13 @@ As a SciToken is a [JSON Web Token](https://jwt.io) at its base, we inherit a sp
 
   | Client      | Server      | Result  |
   |-------------|-------------|---------|
-  | ANY         | ANY         | Success |
+  | ANY         | ANY         | Error   |
   | ANY         | example.com | Success |
-  | example.com | ANY         | Fail    |
+  | example.com | ANY         | Error   |
   | example.com | example.com | Success |
   | notwork.com | example.com | Fail    |
+
+  The server cannot apply `ANY`, as that is invalid.
 
 * *jti* (JWT ID): The interpretation for `jti` is unchanged from the RFC. It is a unique identifier that protects against replay attacks, improves traceability of tokens through a distributed system, and enables revocation.  The `jti` claim is OPTIONAL.
 

--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -19,7 +19,7 @@ As a SciToken is a [JSON Web Token](https://jwt.io) at its base, we inherit a sp
 
 * *iss* (Issuer): The issuer of the SciTokens; this MUST be populated in a token chain.  It MUST contain a unique URL for the organization; this unique key will later be used for validation and bootstrapping trust roots.  This is used to identify the virtual organization (VO) that issues the token; it is expected that services maintain a map of issuer URLs to coarse-grained authorizations.
 
-* *aud* (Audience): A service the SciToken is authorized to access.  For example, if the VO has write access to several storage services, this claim may be utilized to limit a token to a single endpoint URI.  As in RFC7519, the `aud` claim is not necessarily a URI: for example, it might be the name of a target site.   The service may accept several different possible audiences; the service endpoint at `https://storage.example.com` may accept an audience of either `Site_Example` or `https://storage.example.com` but ought to reject an audience of `https://www.google.com`.  The `aud` claim is OPTIONAL.
+* *aud* (Audience): A service the SciToken is authorized to access.  For example, if the VO has write access to several storage services, this claim may be utilized to limit a token to a single endpoint URI.  As in RFC7519, the `aud` claim is not necessarily a URI: for example, it might be the name of a target site.   The service may accept several different possible audiences; the service endpoint at `https://storage.example.com` may accept an audience of either `Site_Example` or `https://storage.example.com` but ought to reject an audience of `https://www.google.com`.  The `aud` claim is OPTIONAL in version 1.0, mandatory in 2.0.
 
 * *jti* (JWT ID): The interpretation for `jti` is unchanged from the RFC. It is a unique identifier that protects against replay attacks, improves traceability of tokens through a distributed system, and enables revocation.  The `jti` claim is OPTIONAL.
 
@@ -97,21 +97,22 @@ Suppose we would like to sign the following JWT header and payload:
   "iss": "https://scitokens.org/cms",
   "iat": 1509988190,
   "scope": "read:/store write:/store/user/bbockelm",
-  "nbf": 1509988190
+  "nbf": 1509988190,
+  "ver": "scitoken:2.0",
+  "aud": "https://cms.example.com"
 }
 ```
 
 Then, the corresponding base64-encoded and signed payload would be (line breaks are given only for clarity; should not be included in the actual token):
 
 ```
-eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJiYm9ja2VsbSIsImV4cCI6MTUxMDAwMT
-I1MiwiaXNzIjoiaHR0cHM6Ly9kZW1vLnNjaXRva2Vucy5vcmciLCJpYXQiOjE1MTAwMDA2NTIsInNjc
-CI6InJlYWQ6L3N0b3JlIHdyaXRlOi9zdG9yZS91c2VyL2Jib2NrZWxtIiwibmJmIjoxNTEwMDAwNjUy
-fQ.oFYtTmTDDYiBpxj2jxKnFdRXoxKijspu3vTP990w4tnFVb91-5ahSCcHB82RpzyszzaDbCnU1PXo
-rN-psHawXh4pSKuv-OxtupSZlNE1_djPBgn84voRTj5pjgyS5L6EDBuyKzo1R0h9UuOJu7-VtgtbObY
-4TNx1GXdYZqQPYQFFqfiEsvG8LaRHpguCr-siTpoHFLQoYCRP8l8pHhyaXwwkNGfZJNAtNtj0UzuR_0
-lkrAjpx118PxmPa0pMA8FPdSNRLtY8T4CDUN4FbUk-E4-V9OE8HCqdYyRtLTPUASyGtRzMfn_clynW8
-BehtZjh9EneN9ceHPF_ddAFMrN_fA
+eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiYm9ja2VsbSIsImV4cCI6MTUwOTk5MT
+c5MCwiaXNzIjoiaHR0cHM6Ly9zY2l0b2tlbnMub3JnL2NtcyIsImlhdCI6MTUwOTk4ODE5MCwic2Nvc
+GUiOiJyZWFkOi9zdG9yZSB3cml0ZTovc3RvcmUvdXNlci9iYm9ja2VsbSIsIm5iZiI6MTUwOTk4ODE5
+MCwidmVyIjoic2NpdG9rZW46Mi4wIiwiYXVkIjoiaHR0cHM6Ly9jbXMuZXhhbXBsZS5jb20ifQ.fCty
+ZQQNPaowQ5FXFVIlbt2Qpb4ui8Bkl1qXpwLKI3FQ0AKP64Ozf7NLKI8nRHaAqh9XRQAxB9YtAJAeHri
+SN422-CraARoYyBdrZMtwlxphOLPkpuxbIusVYB3r4zIRt4BoB7NlqLqwVV2e5rGtkJGvi9tpY2FNr7
+eZ6eBrzAg
 ```
 
 Examples SciToken scope
@@ -151,7 +152,7 @@ To stageout to `/store/user/bbockelm`, a part of the CMS namespace at the CMS si
 }
 ```
 
-The implementation of `site` is purposely ambiguous; hence, the `aud` claim may be used to restrict a token to a specific endpoint:
+The implementation of `site` is purposely ambiguous; hence, the `aud` claim must be used to restrict a token to a specific endpoint:
 
 ```
 {

--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -23,6 +23,7 @@ As a SciToken is a [JSON Web Token](https://jwt.io) at its base, we inherit a sp
 
 * *jti* (JWT ID): The interpretation for `jti` is unchanged from the RFC. It is a unique identifier that protects against replay attacks, improves traceability of tokens through a distributed system, and enables revocation.  The `jti` claim is OPTIONAL.
 
+* *ver* (Version): The version of the token.  `ver` is used to version the claim formats and attribute names.  The format of the `ver` claim is: `<profile>:<version>`.  The `ver` claim is optional.  If absent, the default is `scitoken:1.0`
 
 SciToken Claim Semantics
 ------------------------

--- a/technical_docs/Claims.md
+++ b/technical_docs/Claims.md
@@ -99,7 +99,7 @@ Suppose we would like to sign the following JWT header and payload:
   "scope": "read:/store write:/store/user/bbockelm",
   "nbf": 1509988190,
   "ver": "scitoken:2.0",
-  "aud": "https://cms.example.com"
+  "aud": "https://transfer-server.example.com"
 }
 ```
 

--- a/technical_docs/Verification.md
+++ b/technical_docs/Verification.md
@@ -66,6 +66,6 @@ For tokens with no `ver` attribute or `scitoken:1.0`:
 For tokens with `ver` = `scitoken:2.0`
 
 * Unknown claims are ignored and not used for authorization.
-* Required Supported Claims:  ver, sub, nbf, exp, iss, aud, jti, iat, scope
+* Required Supported Claims:  `ver`, `sub`, `nbf`, `exp`, `iss`, `aud`, `jti`, `iat`, `scope`
 * Signature algorithms and RS256, ES256 MUST be supported.
 

--- a/technical_docs/Verification.md
+++ b/technical_docs/Verification.md
@@ -51,7 +51,21 @@ SciToken-specific Claim Processing
 
 See the [claims definition](Claims.md) page for information on the SciTokens claim language.  In this section, we describe how to perform validation of claims.
 
+A token's version is found in the `ver` attribute.  If absent, the `ver` is `scitoken:1.0`
+
+### Version 1.0
+
+For tokens with no `ver` attriibute or `scitoken:1.0`:
+
 * All claims MUST be considered valid by the entity performing validation.  If there are any unknown claims attributes - or claim values that cannot be validated - the entire token must be considered INVALID.  A token must be considered completely valid or invalid.
 * Claim validation should proceed with the base token in any given chain; all parent token claims MUST be processed before a child's claims.  [This item will be updated in the future as we develop any use cases for chaining.]
 * New claim attributes MUST only be present in the base claim.  Any claim attributes in child claims MUST be also be present in the base claim.  Hence, the chaining mechanism may only be utilized to reduce or limit the authorizations in a claim - new ones MUST NOT be added.
+
+### Version 2.0
+
+For tokens with `ver` = `scitoken:2.0`
+
+* Unknown claims are ignored and not used for authorization.
+* Required Supported Claims:  ver, sub, nbf, exp, iss, aud, jti, iat, scope
+* Signature algorithms and RS256, ES256 MUST be supported.
 

--- a/technical_docs/Verification.md
+++ b/technical_docs/Verification.md
@@ -55,7 +55,7 @@ A token's version is found in the `ver` attribute.  If absent, the `ver` is `sci
 
 ### Version 1.0
 
-For tokens with no `ver` attriibute or `scitoken:1.0`:
+For tokens with no `ver` attribute or `scitoken:1.0`:
 
 * All claims MUST be considered valid by the entity performing validation.  If there are any unknown claims attributes - or claim values that cannot be validated - the entire token must be considered INVALID.  A token must be considered completely valid or invalid.
 * Claim validation should proceed with the base token in any given chain; all parent token claims MUST be processed before a child's claims.  [This item will be updated in the future as we develop any use cases for chaining.]


### PR DESCRIPTION
Added documentation on mandatory `ver` tag.  A few notes:

* If absent, `ver` is defaulted to `scitoken:1.0`
* In 2.0, `aud` and `ver` is mandatory.  The wording on that is difficult.  Optional in 1.0, mandatory in 2.0.  Please read through it.
* I noted in 2.0 that there is a core set of mandatory claims, as well as signature algorithms.
* Probably need to expand on the verification paragraph.